### PR TITLE
Add diff bot world and clarify launch paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,28 @@ The `workspace` directory in this repository is mounted into the container as `/
 ## Models
 
 A simple differential drive robot model is available at `workspace/models/simple_diff_bot`.
-You can launch the model with Ignition Gazebo:
+You can launch the model with Ignition Gazebo. When running directly on the host, use the path as shown below. Inside the container, prefix the path with `/` because `workspace` is mounted at `/workspace`.
 
 ```bash
-ign gazebo -v 4 workspace/models/simple_diff_bot/model.sdf
+ign gazebo -v 4 workspace/models/simple_diff_bot/model.sdf   # on the host
+ign gazebo -v 4 /workspace/models/simple_diff_bot/model.sdf  # in the container
 ```
-<<<<<<< codex/ignition-gazebo用の差動二輪ロボット作成
 
-## World
+## Worlds
 
-A minimal world file which spawns the robot using an `<include>` tag is
-available under `workspace/worlds`.
-Add the `workspace` directory to `IGN_GAZEBO_RESOURCE_PATH` so the simulator can
-locate the model and then launch the world:
+A minimal world file which spawns the robot using an `<include>` tag is available under `workspace/worlds`.
+Add the `workspace` directory to `IGN_GAZEBO_RESOURCE_PATH` so the simulator can locate the model and then launch the world:
 
 ```bash
-export IGN_GAZEBO_RESOURCE_PATH=$(pwd)/workspace
-ign gazebo -v 4 workspace/worlds/simple_diff_bot_world.sdf
+export IGN_GAZEBO_RESOURCE_PATH=$(pwd)/workspace   # on the host
+export IGN_GAZEBO_RESOURCE_PATH=/workspace        # in the container
+ign gazebo -v 4 workspace/worlds/simple_diff_bot_world.sdf   # on the host
+ign gazebo -v 4 /workspace/worlds/simple_diff_bot_world.sdf  # in the container
 ```
-=======
->>>>>>> develop
+
+Another world file `simple_diff_bot.world` includes the model via a relative path, so no additional environment variables are required. Launching the world instead of the model starts Ignition Gazebo with this preconfigured world:
+
+```bash
+ign gazebo -v 4 workspace/worlds/simple_diff_bot.world   # on the host
+ign gazebo -v 4 /workspace/worlds/simple_diff_bot.world  # in the container
+```

--- a/workspace/worlds/simple_diff_bot.world
+++ b/workspace/worlds/simple_diff_bot.world
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+    <include>
+      <uri>../models/simple_diff_bot/model.sdf</uri>
+      <name>simple_diff_bot</name>
+      <pose>0 0 0 0 0 0</pose>
+    </include>
+  </world>
+</sdf>


### PR DESCRIPTION
## Summary
- add `simple_diff_bot.world` that includes the robot model via a relative path
- document running Ignition Gazebo from world and model files
- mention path differences when running on host vs in container

## Testing
- `colcon test` *(fails: command not found)*