### PR TITLE
Add ground plane model and update world

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ ign gazebo -v 4 /workspace/models/simple_diff_bot/model.sdf  # in the container
 ## Worlds
 
 A minimal world file which spawns the robot using an `<include>` tag is available under `workspace/worlds`.
-Add the `workspace` directory to `IGN_GAZEBO_RESOURCE_PATH` so the simulator can locate the model and then launch the world:
+The world also brings in a basic ground plane from `workspace/models/ground_plane` so the robot spawns on a flat surface.
+Add the `workspace/models` directory to `IGN_GAZEBO_RESOURCE_PATH` so the simulator can locate the model and then launch the world:
 
 ```bash
-export IGN_GAZEBO_RESOURCE_PATH=$(pwd)/workspace   # on the host
-export IGN_GAZEBO_RESOURCE_PATH=/workspace        # in the container
+export IGN_GAZEBO_RESOURCE_PATH=$(pwd)/workspace/models   # on the host
+export IGN_GAZEBO_RESOURCE_PATH=/workspace/models        # in the container
 ign gazebo -v 4 workspace/worlds/simple_diff_bot_world.sdf   # on the host
 ign gazebo -v 4 /workspace/worlds/simple_diff_bot_world.sdf  # in the container
 ```

--- a/workspace/models/ground_plane/model.config
+++ b/workspace/models/ground_plane/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<model>
+  <name>ground_plane</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+  <description>A basic ground plane.</description>
+  <author>
+    <name>Example Author</name>
+    <email>example@example.com</email>
+  </author>
+</model>

--- a/workspace/models/ground_plane/model.sdf
+++ b/workspace/models/ground_plane/model.sdf
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="ground_plane">
+    <static>true</static>
+    <link name="link">
+      <collision name="collision">
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <surface>
+          <contact>
+            <collide_without_contact>true</collide_without_contact>
+          </contact>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+            </ode>
+          </friction>
+        </surface>
+      </collision>
+      <visual name="visual">
+        <geometry>
+          <plane>
+            <normal>0 0 1</normal>
+            <size>100 100</size>
+          </plane>
+        </geometry>
+        <material>
+          <script>
+            <uri>file://media/materials/scripts/gazebo.material</uri>
+            <name>Gazebo/Grey</name>
+          </script>
+        </material>
+      </visual>
+    </link>
+  </model>
+</sdf>

--- a/workspace/worlds/simple_diff_bot_world.sdf
+++ b/workspace/worlds/simple_diff_bot_world.sdf
@@ -2,6 +2,11 @@
 <sdf version="1.6">
   <world name="default">
     <include>
+      <uri>model://ground_plane</uri>
+      <name>ground_plane</name>
+      <pose>0 0 0 0 0 0</pose>
+    </include>
+    <include>
       <uri>model://simple_diff_bot</uri>
       <name>simple_diff_bot</name>
       <pose>0 0 0 0 0 0</pose>


### PR DESCRIPTION
## Summary
- add new `ground_plane` model
- include the ground plane in `simple_diff_bot_world.sdf`
- document the ground plane in README

## Testing
- `grep -n IGN_GAZEBO_RESOURCE_PATH README.md`
- `grep -n ground_plane workspace/worlds/simple_diff_bot_world.sdf`
