### PR TITLE
Handle optional branch and commit

### DIFF
--- a/ros2/clone_repos.sh
+++ b/ros2/clone_repos.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
+YAML_FILE="$BASE_DIR/repos.yaml"
+SRC_DIR="$BASE_DIR/ros2_ws/src"
+
+if [ ! -f "$YAML_FILE" ]; then
+  echo "Error: $YAML_FILE not found." >&2
+  exit 1
+fi
+
+mkdir -p "$SRC_DIR"
+
+awk_cmd='
+function print_repo() {
+  if (name != "") {
+    print name "|" repo "|" branch "|" commit
+  }
+}
+/^\s*- name:/ {
+  print_repo();
+  name=$0; sub(/.*- name:[ ]*/, "", name);
+  repo=""; branch=""; commit="";
+  next;
+}
+/^\s*repo:/ { repo=$0; sub(/.*repo:[ ]*/, "", repo); next; }
+/^\s*branch:/ { branch=$0; sub(/.*branch:[ ]*/, "", branch); next; }
+/^\s*commit:/ { commit=$0; sub(/.*commit:[ ]*/, "", commit); next; }
+END { print_repo() }'
+
+while IFS='|' read -r NAME REPO BRANCH COMMIT; do
+  [ -z "$NAME" ] && continue
+  TARGET="$SRC_DIR/$NAME"
+  echo "==== Processing $NAME ===="
+  if [ ! -d "$TARGET" ]; then
+    echo "Cloning $REPO into $TARGET"
+    git clone "$REPO" "$TARGET"
+  else
+    echo "Directory $TARGET already exists, skipping clone"
+  fi
+  cd "$TARGET"
+  if [ -n "$BRANCH" ]; then
+    echo "Checking out branch $BRANCH"
+    git fetch origin "$BRANCH"
+    git checkout "$BRANCH"
+  else
+    echo "Using default branch"
+  fi
+  if [ -n "$COMMIT" ]; then
+    echo "Resetting to commit $COMMIT"
+    git fetch --all
+    git reset --hard "$COMMIT"
+  fi
+  cd "$BASE_DIR"
+  echo ""
+done < <(grep -v '^repositories:' "$YAML_FILE" | awk "$awk_cmd")

--- a/ros2/repos.yaml
+++ b/ros2/repos.yaml
@@ -1,0 +1,10 @@
+repositories:
+  - name: example_repo
+    repo: https://github.com/example/example_repo.git
+    # branch and commit are optional
+    branch: main
+    commit: <commit-sha>
+  - name: another_repo
+    repo: https://github.com/example/another_repo.git
+    branch: main
+    commit: <commit-sha>


### PR DESCRIPTION
## Summary
- allow `clone_repos.sh` to clone using the default branch when `branch` or `commit` are not specified
- document optional fields in `repos.yaml`

## Testing
- `bash ros2/clone_repos.sh` *(fails: no repos exist or network blocked)*